### PR TITLE
F/#11 디버깅 로그 코드 추가

### DIFF
--- a/src/main/java/com/se/se_file_server/file/application/error/FileDownloadErrorCode.java
+++ b/src/main/java/com/se/se_file_server/file/application/error/FileDownloadErrorCode.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 public enum FileDownloadErrorCode implements ErrorCode {
 
   DOWNLOAD_PATH_DOES_NOT_EXISTS(400, "FDLE01", "파일을 다운로드 할 경로가 존재하지 않음"),
-  FILE_DOES_NOT_EXISTS(400, "FDLE02", "파일이 존재하지 않음");
+  FILE_DOES_NOT_EXISTS(400, "FDLE02", "파일이 존재하지 않음"),
+  UNKNOWN_DOWNLOAD_ERROR(400, "FDLE03", "파일 다운로드 도중 알 수 없는 오류 발생");
 
   private final String code;
   private final String message;

--- a/src/main/java/com/se/se_file_server/file/application/error/FileUploadErrorCode.java
+++ b/src/main/java/com/se/se_file_server/file/application/error/FileUploadErrorCode.java
@@ -10,7 +10,7 @@ public enum FileUploadErrorCode implements ErrorCode {
   INVALID_FILE_NAME(400, "FULE02", "유효하지 않은 파일명"),
   INVALID_FILE_SIZE(400, "FULE03", "유효하지 않은 파일 크기"),
   FILE_SIZE_LIMIT_EXCEEDED(400, "FULE04", "파일 용량 초과"),
-  UNKNOWN_UPLOAD_ERROR_CAUSED(400, "FULE05", "업로드 도중 알 수 없는 오류 발생"),
+  UNKNOWN_UPLOAD_ERROR(400, "FULE05", "업로드 도중 알 수 없는 오류 발생"),
   DATABASE_ERROR_CAUSED(400, "FULE06", "업로드 도중 데이터베이스에서 오류 발생"),
   FILE_DOES_NOT_EXISTS(400, "FULE07", "파일이 존재하지 않음");
 

--- a/src/main/java/com/se/se_file_server/file/application/service/FileDeleteService.java
+++ b/src/main/java/com/se/se_file_server/file/application/service/FileDeleteService.java
@@ -3,9 +3,12 @@ package com.se.se_file_server.file.application.service;
 import com.se.se_file_server.common.domain.exception.BusinessException;
 import com.se.se_file_server.file.application.error.FileDeleteErrorCode;
 import com.se.se_file_server.file.domain.entity.File;
+import com.se.se_file_server.file.infra.api.FileDownloadApiController;
 import com.se.se_file_server.file.infra.repository.FileJpaRepository;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
@@ -22,6 +25,8 @@ public class FileDeleteService {
   @Autowired
   private final FileDownloadService fileDownloadService;
 
+  private static final Logger logger = LoggerFactory.getLogger(FileDownloadApiController.class);
+
   @Transactional
   public void delete(final String fileName){
     File file = fileJpaRepository.findBySaveName(fileName).orElseThrow(() -> {
@@ -31,6 +36,7 @@ public class FileDeleteService {
     Resource resource;
     try{
       resource = fileDownloadService.loadFileAsResource(fileName);
+      logger.debug("[DELETE] Delete target is " + resource.getFile().getAbsolutePath());
     }
     catch (Exception e){
       // DB상에는 파일이 있는데, 실제 파일은 없는 경우 DB 에서 삭제

--- a/src/main/java/com/se/se_file_server/file/application/service/FileDownloadService.java
+++ b/src/main/java/com/se/se_file_server/file/application/service/FileDownloadService.java
@@ -2,6 +2,7 @@ package com.se.se_file_server.file.application.service;
 
 import com.se.se_file_server.common.domain.exception.BusinessException;
 import com.se.se_file_server.file.application.error.FileUploadErrorCode;
+import com.se.se_file_server.file.infra.api.FileDownloadApiController;
 import com.se.se_file_server.file.infra.config.FileUploadProperties;
 import com.se.se_file_server.file.domain.entity.File;
 import com.se.se_file_server.file.application.error.FileDownloadErrorCode;
@@ -10,17 +11,23 @@ import java.net.MalformedURLException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 public class FileDownloadService {
   private final Path fileLocation;
 
   @Autowired
   private FileJpaRepository fileJpaRepository;
+
+  private static final Logger logger = LoggerFactory.getLogger(FileDownloadApiController.class);
 
   @Autowired
   public FileDownloadService(FileUploadProperties prop) {
@@ -37,15 +44,24 @@ public class FileDownloadService {
   public Resource loadFileAsResource(String fileName) {
     try {
       Path filePath = this.fileLocation.resolve(fileName).normalize();
+      logger.debug("[DOWNLOAD] Download path is " + filePath.toString());
+
       Resource resource = new UrlResource(filePath.toUri());
 
-      if(resource.exists())
+      if(resource.exists()){
+        logger.debug("[DOWNLOAD] Resource exists at " + resource.getFile().getAbsolutePath());
         return resource;
-      else
+      }
+      else{
         throw new BusinessException(FileDownloadErrorCode.FILE_DOES_NOT_EXISTS);
+      }
+
     }
-    catch(MalformedURLException e) {
+    catch (MalformedURLException e) {
       throw new BusinessException(FileDownloadErrorCode.FILE_DOES_NOT_EXISTS);
+    }
+    catch (Exception e){
+      throw new BusinessException(FileDownloadErrorCode.UNKNOWN_DOWNLOAD_ERROR);
     }
   }
 

--- a/src/main/java/com/se/se_file_server/file/application/service/FileDownloadService.java
+++ b/src/main/java/com/se/se_file_server/file/application/service/FileDownloadService.java
@@ -44,21 +44,23 @@ public class FileDownloadService {
   public Resource loadFileAsResource(String fileName) {
     try {
       Path filePath = this.fileLocation.resolve(fileName).normalize();
-      logger.debug("[DOWNLOAD] Download path is " + filePath.toString());
+      logger.debug("[DL Service] Download path is " + filePath.toString());
 
       Resource resource = new UrlResource(filePath.toUri());
 
-      if(resource.exists()){
-        logger.debug("[DOWNLOAD] Resource exists at " + resource.getFile().getAbsolutePath());
-        return resource;
-      }
-      else{
+      if(!resource.exists())
         throw new BusinessException(FileDownloadErrorCode.FILE_DOES_NOT_EXISTS);
-      }
+
+      logger.debug("[DL Service] Resource's description is " + resource.getDescription());
+      logger.debug("[DL Service] Resource exists at " + resource.getFile().getAbsolutePath());
+      return resource;
 
     }
     catch (MalformedURLException e) {
       throw new BusinessException(FileDownloadErrorCode.FILE_DOES_NOT_EXISTS);
+    }
+    catch (BusinessException be){
+      throw be;
     }
     catch (Exception e){
       throw new BusinessException(FileDownloadErrorCode.UNKNOWN_DOWNLOAD_ERROR);

--- a/src/main/java/com/se/se_file_server/file/application/service/FileUploadService.java
+++ b/src/main/java/com/se/se_file_server/file/application/service/FileUploadService.java
@@ -82,16 +82,16 @@ public class FileUploadService {
 
       try{
         fileJpaRepository.save(saveFile);
-        logger.debug("[UPLOAD] File saved at " + targetLocation);
+        logger.debug("[UL Service] File saved at " + targetLocation);
       }
       catch (Exception ex){
         java.io.File savedFile = new java.io.File(targetLocation.toString());
         if(savedFile.exists())
           savedFile.delete();
 
+        logger.debug("[UL Service] Failed to save file at " + targetLocation);
         throw new BusinessException(FileUploadErrorCode.DATABASE_ERROR_CAUSED);
       }
-
 
       return saveFile;
     }


### PR DESCRIPTION
디버깅 로그 코드 추가

삭제가 안되는 버그는 파일을 삭제해도 nginx proxy에서 cache한 것을 계속 보내주고 있었기 때문임.
npm에서 cache 옵션 끄니 정상 작동함.